### PR TITLE
[VN-10926] - Expose snap sensitivity props

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,27 @@ Type: `boolean`
 
 Disabled by default. By default, a user can expand the bottom sheet only by dragging a header or the overlay. This option enables expanding the bottom sheet on the content dragging.
 
+#### dismissVelocityThreshold
+
+Type: `number`
+
+Minimum velocity threshold for a "strong" flick that should dismiss the sheet. Higher values make it harder to dismiss with small flicks.
+@default 2.0
+
+#### snapPointSensitivityMultiplier
+
+Type: `number`
+
+Velocity multiplier for drags/flicks that affects how aggressively the sheet predicts snap point selection. Lower values make the sheet more conservative in snap point prediction.
+@default 1
+
+#### swipeDismissFromMinSnapOnly
+
+Type: `boolean`
+
+Restricts dismiss swipe actions to only trigger when already at the minimum snap point. When enabled, flick dismissal only works from the bottom snap point, while drag dismissal can still work from any snap point.
+@default false
+
 #### springConfig
 
 Type: `{ mass: number; tension: number; friction: number }`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/PropellerAero/react-spring-bottom-sheet/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "files": [

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -73,7 +73,8 @@ export const BottomSheet = React.forwardRef<
     onDragEnd,
     reserveScrollBarGap = blocking,
     expandOnContentDrag = false,
-    snapPointSensitivityMultiplier = 1.0,
+    snapPointSensitivityMultiplierDownwards = 1.0,
+    snapPointSensitivityMultiplierUpwards = 1.0,
     dismissVelocityThreshold = 2.0,
     swipeDismissFromMinSnapOnly = false,
     ...props
@@ -510,7 +511,11 @@ export const BottomSheet = React.forwardRef<
       minSnapRef.current,
       Math.min(
         maxSnapRef.current,
-        rawY + predictedDistance * snapPointSensitivityMultiplier
+        rawY +
+          predictedDistance *
+            (direction < 0
+              ? snapPointSensitivityMultiplierUpwards
+              : snapPointSensitivityMultiplierDownwards)
       )
     )
     // is within 10 pixels of the min snap point

--- a/src/BottomSheet.tsx
+++ b/src/BottomSheet.tsx
@@ -73,6 +73,9 @@ export const BottomSheet = React.forwardRef<
     onDragEnd,
     reserveScrollBarGap = blocking,
     expandOnContentDrag = false,
+    snapPointSensitivityMultiplier = 1.0,
+    dismissVelocityThreshold = 2.0,
+    swipeDismissFromMinSnapOnly = false,
     ...props
   },
   forwardRef
@@ -502,16 +505,32 @@ export const BottomSheet = React.forwardRef<
 
     const rawY = memo + my
     const predictedDistance = my * velocity
+
     const predictedY = Math.max(
       minSnapRef.current,
-      Math.min(maxSnapRef.current, rawY + predictedDistance * 2)
+      Math.min(
+        maxSnapRef.current,
+        rawY + predictedDistance * snapPointSensitivityMultiplier
+      )
     )
+    // is within 10 pixels of the min snap point
+    const isAtMinSnap = Math.abs(memo - minSnapRef.current) < 10
+
+    const dismissSwipeConditions = swipeDismissFromMinSnapOnly
+      ? // if its a fast flick and already at the min snap point
+        isAtMinSnap && velocity > dismissVelocityThreshold
+      : // if final drag location plus predicted distance is less than half the min snap point
+        rawY + predictedDistance < minSnapRef.current / 2 &&
+        velocity > dismissVelocityThreshold
+
+    // drag position is below 65% of the min snap point
+    const dismissDragConditions = rawY < minSnapRef.current * 0.65
 
     if (
       !down &&
       onDismiss &&
       direction > 0 &&
-      rawY + predictedDistance < minSnapRef.current / 2
+      (dismissDragConditions || dismissSwipeConditions)
     ) {
       cancel()
       onDismiss()
@@ -558,7 +577,7 @@ export const BottomSheet = React.forwardRef<
 
     if (first) {
       send({ type: 'DRAG' })
-      onDragStartRef.current?.()    // ← Add this line
+      onDragStartRef.current?.()
     }
 
     if (last) {
@@ -570,7 +589,7 @@ export const BottomSheet = React.forwardRef<
           source: 'dragging',
         },
       })
-      onDragEndRef.current?.()      // ← Add this line
+      onDragEndRef.current?.()
 
       return memo
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,14 @@ export type Props = {
    * Velocity multiplier for drags/flicks
    * @default 1
    */
-  snapPointSensitivityMultiplier?: number
+  snapPointSensitivityMultiplierDownwards?: number
+
+
+  /**
+   * Velocity multiplier for drags/flicks
+   * @default 1
+   */
+  snapPointSensitivityMultiplierUpwards?: number
 
   /**
    * Restricts dismiss swipe actions to only trigger when already at the minimum snap point

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,13 +168,32 @@ export type Props = {
   /**
    * Open immediatly instead of initially animating from a closed => open state, useful if the bottom sheet is visible by default and the animation would be distracting
    */
-  skipInitialTransition?: boolean,
+  skipInitialTransition?: boolean
 
   /**
    * Expand the bottom sheet on the content dragging. By default user can expand the bottom sheet only by dragging the header or overlay. This option enables expanding on dragging the content.
    * @default expandOnContentDrag === false
    */
-  expandOnContentDrag?: boolean,
+  expandOnContentDrag?: boolean
+
+  /**
+   * Minimum velocity threshold for a "strong" flick that should dismiss the sheet.
+   * @default 2.0
+   */
+  dismissVelocityThreshold?: number
+
+  /**
+   * Velocity multiplier for drags/flicks
+   * @default 1
+   */
+  snapPointSensitivityMultiplier?: number
+
+  /**
+   * Restricts dismiss swipe actions to only trigger when already at the minimum snap point
+   * Note: if onDismiss is not set then nothing will happen 
+   * @default false
+   */
+  swipeDismissFromMinSnapOnly?: boolean
 } & Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'>
 
 export interface RefHandles {


### PR DESCRIPTION
expose the snapPointSensitivity multiplier to control the sensitivity between swipes for different snap points
expose dismiss velocity threshold so that we can set a minimum swipe velocity to allow it to dismiss the bottomsheet 
expose swipeDismissFromMinSnapOnly to control whether or not dismiss swipes can be triggered from any snap point or just the minimum snap point